### PR TITLE
[31기 김정수] modify : nav 로그아웃 방식 변경 

### DIFF
--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -18,11 +18,19 @@ const Nav = () => {
     navigate('/');
   };
 
-  const kakaoLogout = () => {
-    removeProfile();
-    removeNickName();
-    removeToken();
-    goToMain();
+  const kakaoLog = () => {
+    window.Kakao.init(process.env.REACT_APP_KAKAO);
+    if (!window.Kakao.Auth.getAccessToken()) {
+      alert('Not logged in.');
+      return;
+    }
+    window.Kakao.Auth.logout(function () {
+      removeProfile();
+      removeNickName();
+      removeToken();
+      goToMain();
+      alert('logout ok\naccess token -> ' + window.Kakao.Auth.getAccessToken());
+    });
   };
 
   return (
@@ -48,7 +56,7 @@ const Nav = () => {
           <LoginMenu to="/login">로그인</LoginMenu>
         ) : (
           <LoginWrap>
-            <LogoutBtn onClick={kakaoLogout}>로그아웃</LogoutBtn>
+            <LogoutBtn onClick={kakaoLog}>로그아웃</LogoutBtn>
             <LoginMenu to="/wish-list">찜</LoginMenu>
             <ProfileImg src={getProfile()} alt="카카오프로필임시" />
           </LoginWrap>

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -1,17 +1,11 @@
 import { useNavigate } from 'react-router-dom';
 import API from '../../config';
-import {
-  setToken,
-  setProfile,
-  setNickname,
-  removeNickName,
-  removeProfile,
-  removeToken,
-} from '../../utils';
+import { setToken, setProfile, setNickname } from '../../utils';
 import styled from 'styled-components';
 
 const Login = () => {
   const navigate = useNavigate();
+
   function kakaLogin() {
     window.Kakao.init(process.env.REACT_APP_KAKAO);
     window.Kakao.Auth.login({
@@ -36,22 +30,6 @@ const Login = () => {
       },
     });
   }
-
-  const kakaoLogout = () => {
-    window.Kakao.API.request({
-      url: '/v1/user/unlink',
-      success: function (res) {
-        removeProfile();
-        removeNickName();
-        removeToken();
-        alert('로그아웃');
-      },
-      fail: function (err) {
-        alert('실패: ' + JSON.stringify(err));
-      },
-    });
-  };
-
   const goToMain = () => {
     alert('로그인에 성공하였습니다.');
     navigate('/');
@@ -71,7 +49,6 @@ const Login = () => {
             src="/images/kakao_login_medium_wide.png"
           />
         </KaKaoBtn>
-        <button onClick={kakaoLogout}>로그아웃</button>
       </LoginBox>
     </LoginSection>
   );


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [x] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
nav 로그아웃 기능 localstorage remove 뿐 아니라 카카오 엑세스 토큰 까지 제거 하는 로그아웃 

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
login 페이지에 원활한 통신확인을 위해 만들어 두었던  소셜로그인 연동해제 logout 부분 nav쪽 logout으로 합쳤습니다
로그인시 생겼던 카카오측 엑세스 토큰 삭제쪽으로 방법 변경 



<br />



## :: 성장포인트

문서를 읽어보고 로그인 이외에 다른 카카오 서비스를 이용할 것이 아니라면 token을 쓸 곳도 없고 알아서 연동해제하고 다시 쓸려고 해도 토큰이 사용이 안 되는것을 보고  그냥 냅둬도 되겠거니 하고 

좀 더 상위개념인듯한 연동해제를 선택하여 로그아웃에 집어넣었는데 멘토님의 말씀을 듣고 잘 찾아보니 
지금 당장은 별 상관 없어보이지만 나중에 정말 소셜 로그인을 연동을 통해서 한다면 탈퇴 개념이 된다는 것 을 숙지하였습니다.

추가로  테스트를 하다보니 연동해제가 아닌 로그아웃의 자동로그인은 어떻게 해제 해야되는지 찾아보았는데
![image](https://user-images.githubusercontent.com/89845540/164369179-5f4d2bad-0c91-4b5c-ae70-9dd65466d894.png)
이런 답변을 찾아서 궁금증이 해결되었습니다 



 

